### PR TITLE
Fixed new dlcpacks being recognised as mods

### DIFF
--- a/GameScanner.cs
+++ b/GameScanner.cs
@@ -49,7 +49,7 @@ namespace GTAVModdingLauncher
 					if(Directory.Exists(file))
 					{
 						string filename = Path.GetFileName(file).ToLower();
-						if(!filename.StartsWith("mp") && !filename.StartsWith("patchday"))
+						if(!filename.StartsWith("mp") && !filename.StartsWith("patch"))
 							return true;
 					}
 				}


### PR DESCRIPTION
The new San Andreas Mercenaries update included two new dlcpacks called 'patch2023_01' and 'patch2023_01_g9ec'. These files did not start with 'mp' or 'patchday' so were incorrectly flagged as modified files.

I've changed the check to allow for files beginning with just 'patch', rather than 'patchday'.