### PR TITLE
Add additional game files to GameManifest.xml

### DIFF
--- a/GameManifest.xml
+++ b/GameManifest.xml
@@ -49,10 +49,12 @@
 	<GameFile Name="x64u.rpf" />
 	<GameFile Name="x64v.rpf" />
 	<GameFile Name="x64w.rpf" />
+	<GameFile Name="title.rgl" />
 	
 	<GameFile Name="_commonredist" SteamOnly="true" />
 	<GameFile Name="installers" SteamOnly="true" />
 	<GameFile Name="installscript.vdf" SteamOnly="true" />
+	<GameFile Name="installscript_sdk.vdf" SteamOnly="true" />
 	<GameFile Name="steam_api64.dll" SteamOnly="true" />
 	<GameFile Name="steam_appid.txt" SteamOnly="true" />
 


### PR DESCRIPTION
Some files were removed incorrectly and crashed my vanilla profile, when I revalidated the game I was able to identify which files those were by allowing them to be split into a new profile.

I believe I have marked the only Steam-specific file, but I can change it if you think `title.rgl` is also Steam-specific.